### PR TITLE
Ignore markdown codeblocks for tags

### DIFF
--- a/flatnotes/flatnotes.py
+++ b/flatnotes/flatnotes.py
@@ -162,7 +162,7 @@ class SearchResult(Note):
 
 class Flatnotes(object):
     TAGS_RE = re.compile(r"(?:(?<=^#)|(?<=\s#))\w+(?=\s|$)")
-    MARKDOWN_RE = re.compile(r"`{1,3}.*?`{1,3}", re.DOTALL)
+    CODEBLOCK_RE = re.compile(r"`{1,3}.*?`{1,3}", re.DOTALL)
     TAGS_WITH_HASH_RE = re.compile(r"(?:(?<=^)|(?<=\s))#\w+(?=\s|$)")
 
     def __init__(self, dir: str) -> None:
@@ -204,8 +204,9 @@ class Flatnotes(object):
 
         - The content without the tags.
         - A set of tags converted to lowercase."""
-        content_ex_markdown = re.sub(cls.MARKDOWN_RE, '', content)
-        content_ex_tags, tags = re_extract(cls.TAGS_RE, content_ex_markdown)
+        content_ex_codeblock = re.sub(cls.CODEBLOCK_RE, '', content)
+        _, tags = re_extract(cls.TAGS_RE, content_ex_codeblock)
+        content_ex_tags, _ = re_extract(cls.TAGS_RE, content)
         try:
             tags = [tag.lower() for tag in tags]
             return (content_ex_tags, set(tags))

--- a/flatnotes/flatnotes.py
+++ b/flatnotes/flatnotes.py
@@ -162,6 +162,7 @@ class SearchResult(Note):
 
 class Flatnotes(object):
     TAGS_RE = re.compile(r"(?:(?<=^#)|(?<=\s#))\w+(?=\s|$)")
+    MARKDOWN_RE = re.compile(r"`{1,3}.*?`{1,3}", re.DOTALL)
     TAGS_WITH_HASH_RE = re.compile(r"(?:(?<=^)|(?<=\s))#\w+(?=\s|$)")
 
     def __init__(self, dir: str) -> None:
@@ -203,7 +204,8 @@ class Flatnotes(object):
 
         - The content without the tags.
         - A set of tags converted to lowercase."""
-        content_ex_tags, tags = re_extract(cls.TAGS_RE, content)
+        content_ex_markdown = re.sub(cls.MARKDOWN_RE, '', content)
+        content_ex_tags, tags = re_extract(cls.TAGS_RE, content_ex_markdown)
         try:
             tags = [tag.lower() for tag in tags]
             return (content_ex_tags, set(tags))

--- a/flatnotes/flatnotes.py
+++ b/flatnotes/flatnotes.py
@@ -20,7 +20,7 @@ from helpers import empty_dir, re_extract, strip_ext
 from logger import logger
 
 MARKDOWN_EXT = ".md"
-INDEX_SCHEMA_VERSION = "3"
+INDEX_SCHEMA_VERSION = "4"
 
 StemmingFoldingAnalyzer = StemmingAnalyzer() | CharsetFilter(accent_map)
 


### PR DESCRIPTION
Hello,

I took a quick look on how to exclude tags inside markdown codeblocks.
This should help out for #35 

I'm using a second regex to remove all markdown codeblocks.
However, this will also remove the markdown from the return value of `extract_tags`.

I tested the code with various markdown codeblocks. The tag `#TagIgnore` does not show up when searching for `tags:tagignore` while `tags:tagok` shows up. 
Tested with following file:

> Testing
> 
> ``` bash
> Testing more
> #TagIgnore me please
> and this one too #TagIgnore
> ```
> 
> #TagOk
> 
> ` More to #TagIgnore `
> ` One more to
> #TagIgnore `
> `#TagIgnore`
> 
> What is going on? #TagOk
> EOF