### PR TITLE
Set execute permissions for entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,5 @@ COPY flatnotes ./flatnotes
 COPY --from=build ${BUILD_DIR}/flatnotes/dist ./flatnotes/dist
 
 COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
Hello,

the `entrypoint.sh` script has no execution permission. This can either be set for the script in the repo or to be sure inside the Dockerfile. I decided to do the latter.

With this the docker builds successfully on Linux.