### PR TITLE
Allow root URL path to be configured via environment variable (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ docker run -d \
   -e "FLATNOTES_USERNAME=user" \
   -e "FLATNOTES_PASSWORD=changeMe" \
   -e "FLATNOTES_SECRET_KEY=aLongRandomSeriesOfCharacters" \
+  -e "FLATNOTES_ROOT_PATH=/flatnotes" \
   -v "$(pwd)/data:/data" \
   -p "8080:8080" \
   dullage/flatnotes:latest
@@ -82,6 +83,7 @@ services:
       FLATNOTES_USERNAME: "user"
       FLATNOTES_PASSWORD: "changeMe!"
       FLATNOTES_SECRET_KEY: "aLongRandomSeriesOfCharacters"
+      FLATNOTES_ROOT_PATH: "/flatnotes"
     volumes:
       - "./data:/data"
       # Optional. Allows you to save the search index in a different location: 

--- a/flatnotes/config.py
+++ b/flatnotes/config.py
@@ -26,6 +26,8 @@ class Config:
 
         self.totp_key = self.get_totp_key()
 
+        self.root_path = self.get_root_path()
+
     @classmethod
     def get_env(cls, key, mandatory=False, default=None, cast_int=False):
         """Get an environment variable."""
@@ -93,6 +95,9 @@ class Config:
         if totp_key:
             totp_key = b32encode(totp_key.encode("utf-8"))
         return totp_key
+
+    def get_root_path(self):
+        return self.get_env("FLATNOTES_ROOT_PATH", mandatory=False, default="/")
 
 
 config = Config()

--- a/flatnotes/main.py
+++ b/flatnotes/main.py
@@ -23,7 +23,7 @@ from models import (
     SearchResultModel,
 )
 
-app = FastAPI()
+app = FastAPI(root_path=config.root_path)
 flatnotes = Flatnotes(config.data_path)
 
 totp = (


### PR DESCRIPTION
Added option to set `root-path`, based on https://fastapi.tiangolo.com/advanced/behind-a-proxy/.