### PR TITLE
Assign ID to headers with CustomHTMLRenderer

### DIFF
--- a/flatnotes/src/components/NoteViewerEditor.vue
+++ b/flatnotes/src/components/NoteViewerEditor.vue
@@ -189,28 +189,28 @@ export default {
     titleToLoad: { type: String, default: null },
   },
 
-  customHTMLRenderer: {
-    heading( node, { entering, getChildrenText } ) {
-      const tagName = `h${node.level}`;
-
-      if (entering) {
-	return {
-	  type: 'openTag',
-          tagName,
-          attributes: {
-	    id: getChildrenText(node)
-	       .toLowerCase()
-	       .replace(/[^a-z0-9-\s]*/g, '')
-	       .trim()
-	       .replace(/\s/g, '-')
-          }
-        };
-      }
-      return { type: 'closeTag', tagName };
-    }
-  },
-
   data: function () {
+    const customHTMLRenderer = {
+      heading( node, { entering, getChildrenText } ) {
+	const tagName = `h${node.level}`;
+
+	if (entering) {
+	  return {
+	    type: 'openTag',
+	    tagName,
+	    attributes: {
+	      id: getChildrenText(node)
+		  .toLowerCase()
+	          .replace(/[^a-z0-9-\s]*/g, '')
+	          .trim()
+	          .replace(/\s/g, '-')
+	    }
+	  };
+	}
+	return { type: 'closeTag', tagName };
+      }
+    };
+
     return {
       editMode: false,
       draftSaveTimeout: null,

--- a/flatnotes/src/components/NoteViewerEditor.vue
+++ b/flatnotes/src/components/NoteViewerEditor.vue
@@ -178,6 +178,27 @@ import { Viewer } from "@toast-ui/vue-editor";
 import api from "../api";
 import codeSyntaxHighlight from "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight-all.js";
 
+const customHTMLRenderer = {
+  heading( node, { entering, getChildrenText } ) {
+    const tagName = `h${node.level}`;
+
+    if (entering) {
+      return {
+        type: 'openTag',
+        tagName,
+        attributes: {
+          id: getChildrenText(node)
+    	      .toLowerCase()
+              .replace(/[^a-z0-9-\s]*/g, '')
+              .trim()
+              .replace(/\s/g, '-')
+        }
+      };
+    }
+    return { type: 'closeTag', tagName };
+  }
+};
+
 export default {
   components: {
     Viewer,
@@ -190,26 +211,6 @@ export default {
   },
 
   data: function () {
-    const customHTMLRenderer = {
-      heading( node, { entering, getChildrenText } ) {
-	const tagName = `h${node.level}`;
-
-	if (entering) {
-	  return {
-	    type: 'openTag',
-	    tagName,
-	    attributes: {
-	      id: getChildrenText(node)
-		  .toLowerCase()
-	          .replace(/[^a-z0-9-\s]*/g, '')
-	          .trim()
-	          .replace(/\s/g, '-')
-	    }
-	  };
-	}
-	return { type: 'closeTag', tagName };
-      }
-    };
 
     return {
       editMode: false,

--- a/flatnotes/src/components/NoteViewerEditor.vue
+++ b/flatnotes/src/components/NoteViewerEditor.vue
@@ -189,6 +189,27 @@ export default {
     titleToLoad: { type: String, default: null },
   },
 
+  customHTMLRenderer: {
+    heading( node, { entering, getChildrenText } ) {
+      const tagName = `h${node.level}`;
+
+      if (entering) {
+	return {
+	  type: 'openTag',
+          tagName,
+          attributes: {
+	    id: getChildrenText(node)
+	       .toLowerCase()
+	       .replace(/[^a-z0-9-\s]*/g, '')
+	       .trim()
+	       .replace(/\s/g, '-')
+          }
+        };
+      }
+      return { type: 'closeTag', tagName };
+    }
+  },
+
   data: function () {
     return {
       editMode: false,
@@ -200,10 +221,13 @@ export default {
       noteLoadFailedIcon: null,
       noteLoadFailedMessage: "Failed to load Note",
       viewerOptions: {
+	customHTMLRenderer: customHTMLRenderer,
         plugins: [codeSyntaxHighlight],
         extendedAutolinks: true,
       },
-      editorOptions: { plugins: [codeSyntaxHighlight] },
+      editorOptions: {
+        customHTMLRenderer: customHTMLRenderer,
+        plugins: [codeSyntaxHighlight] },
     };
   },
 


### PR DESCRIPTION
I used ToastUI's [`customHTMLRenderer`](https://github.com/nhn/tui.editor/blob/master/docs/en/custom-html-renderer.md) to assign an `id` attribute to all headers equal to the sanitized version of the text of that header.

a simplified version of this can be found in the customHTMLRenderer docs linked above, but my version is a little more extensive in the way it sanitizes the text as it removes all non-alphanumerical characters. Here are some examples of the sanitization:

- `"$$!!£!HeADinG \\1!  !" -> "heading-1"` 
- `"Slightly more 'normal' heading 2" -> "slightly-more-normal-heading-2"`
- you can test this yourself with this [jsfiddle](https://jsfiddle.net/9hr1uy2f/)

the sanitized text is then set as the header's id attribute, which allows for linking in markdown, and therefore tables of content and header tagging (#34). This is very similar, in fact practically the exact same, as how it is done in github, as shown below:

`[link to section 1](#section-1)` links to header with text that sanitizes to `"section-1"`
so for instance `# Section 1` or `### SECTION 1!`

The use of `customHTMLRenderer` is a really powerful addition, as it allows to add any parameters that you want to add in the future, like [latex support](https://nhn.github.io/tui.editor/latest/tutorial-example13-creating-plugin) (#61)


I tested this on my homeserver which runs in docker and everything ran smoothly and as expected. Perhaps some more testing could be done to see if the sanitizer works as intended for all titles, but because flatnotes is selfhosted this doesnt create any security flaw and as it stands now this solution works for everyday users as most people dont need fancy symbols in their headers.