### PR TITLE
Fix API being inaccessible when using FLATNOTES_AUTH_TYPE=none

### DIFF
--- a/flatnotes/auth.py
+++ b/flatnotes/auth.py
@@ -23,10 +23,11 @@ def create_access_token(data: dict):
     return encoded_jwt
 
 
-async def validate_token(token: str = Depends(oauth2_scheme)):
+async def validate_token():
     if config.auth_type == AuthType.NONE:
         return
     try:
+        token = Depends(oauth2_scheme)
         payload = jwt.decode(
             token, config.session_key, algorithms=[JWT_ALGORITHM]
         )


### PR DESCRIPTION
When `FLATNOTES_AUTH_TYPE=none`, the API becomes inaccessible as a format check on the API token is done and is failed before the authentication type is checked.

This commit attempts to fix that by moving the auth type check after the check for the token format.

Full disclaimer that I don't really know what I'm doing with FastAPI - this feels like a bit of a bodge. The context behind this PR is that I use a 3rd-party authentication system on top of Flatnotes and I can't use the API.

Cheers :)