### PR TITLE
Consistent password in README.md for shell run and compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ docker run -d \
   -e "PGID=1000" \
   -e "FLATNOTES_AUTH_TYPE=password" \
   -e "FLATNOTES_USERNAME=user" \
-  -e "FLATNOTES_PASSWORD=changeMe" \
+  -e "FLATNOTES_PASSWORD=changeMe!" \
   -e "FLATNOTES_SECRET_KEY=aLongRandomSeriesOfCharacters" \
   -v "$(pwd)/data:/data" \
   -p "8080:8080" \


### PR DESCRIPTION
The configuration passwords for docker run and for the docker compose file are different. This change picks one of them and keeps it consistent.