### PR TITLE
Add support for docker secrets

### DIFF
--- a/flatnotes/config.py
+++ b/flatnotes/config.py
@@ -65,21 +65,21 @@ class Config:
         return auth_type
 
     def get_username(self):
-        return self.get_env(
+        return self.get_secret("FLATNOTES_USERNAME") or self.get_env(
             "FLATNOTES_USERNAME",
             mandatory=self.auth_type
             not in [AuthType.NONE, AuthType.READ_ONLY],
         )
 
     def get_password(self):
-        return self.get_env(
+        return self.get_secret("FLATNOTES_PASSWORD") or self.get_env(
             "FLATNOTES_PASSWORD",
             mandatory=self.auth_type
             not in [AuthType.NONE, AuthType.READ_ONLY],
         )
 
     def get_session_key(self):
-        return self.get_env(
+        return self.get_secret("FLATNOTES_SECRET_KEY") or self.get_env(
             "FLATNOTES_SECRET_KEY",
             mandatory=self.auth_type
             not in [AuthType.NONE, AuthType.READ_ONLY],
@@ -101,5 +101,13 @@ class Config:
             totp_key = b32encode(totp_key.encode("utf-8"))
         return totp_key
 
+    def get_secret(self, secret_name):
+        assert(secret_name in ["FLATNOTES_USERNAME", "FLATNOTES_PASSWORD", "FLATNOTES_SECRET_KEY"])
+        try:
+            with open("/run/secrets/" + secret_name, "r") as secret_file:
+                return secret_file.read().strip("\n")
+        except Exception:
+            logger.info("Secret file " + secret_name + " not found, fallback to Enviroment variable")
+            return None
 
 config = Config()


### PR DESCRIPTION
If a secrets file exists, it will be prioritized before the env variable.

Usage example:
Populate the mounted secrets files.
```
echo "user" > /tmp/flatnotes_username
echo "1234" > /tmp/flatnotes_password
echo "1234" > /tmp/flatnotes_secret_key
```

The files are now mounted under /run/secrets/flatnotes_...

docker-compose.yml
```
version: "3"

services:
  flatnotes-test:
    container_name: flatnotes-test
    image: dullage/flatnotes:latest
    environment:
      PUID: 1001
      PGID: 1001
      FLATNOTES_AUTH_TYPE: "password"
    ports:
      - "80800:8080"
    secrets:
      - FLATNOTES_USERNAME
      - FLATNOTES_PASSWORD
      - FLATNOTES_SECRET_KEY

secrets:
  FLATNOTES_PASSWORD:
    file: /tmp/flatnotes_password
  FLATNOTES_USERNAME:
    file: /tmp/flatnotes_username
  FLATNOTES_SECRET_KEY:
    file: /tmp/flatnotes_secret_key
```