### PR TITLE
Fix entrypoint preventing rootless docker user.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 echo "WARNING: Breaking changes introduced in version 3.x:"
+echo "  - The port flatnotes uses inside the Docker container has been changed to 8080 (previously 80)."
+echo "  - To accompany the above change, support for the PORT environment variable has been removed."
 echo "  - The note directory inside the Docker container has moved from /app/data to simply /data."
 
 if [ `id -u` -eq 0 ] && [ `id -g` -eq 0 ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,7 @@ if [ `id -u` -eq 0 ] && [ `id -g` -eq 0 ]; then
       main:app \
       --app-dir flatnotes \
       --host 0.0.0.0 \
-      --port ${PORT} \
+      --port 8080 \
       --proxy-headers \
       --forwarded-allow-ips "*"
 else
@@ -43,7 +43,7 @@ else
       main:app \
       --app-dir flatnotes \
       --host 0.0.0.0 \
-      --port ${PORT} \
+      --port 8080 \
       --proxy-headers \
       --forwarded-allow-ips "*"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,39 +1,49 @@
 #!/bin/bash
 
-set -e
-
-USERNAME=flatnotes
-
-echo Setting up user and group...
-addgroup \
-  --gid ${PGID} \
-  ${USERNAME} \
-  || echo "Group '${PGID}' already exists."
-
-adduser \
-  --disabled-password \
-  --gecos "" \
-  --uid ${PUID} \
-  --gid ${PGID} \
-  ${USERNAME} \
-  || echo "User '${PUID}' already exists."
-
-echo Setting file permissions...
-chown -R ${PUID}:${PGID} ${FLATNOTES_PATH}
-
 echo "WARNING: Breaking changes introduced in version 3.x:"
-echo "  - The port flatnotes uses inside the Docker container has been changed to 8080 (previously 80)."
-echo "  - To accompany the above change, support for the PORT environment variable has been removed."
 echo "  - The note directory inside the Docker container has moved from /app/data to simply /data."
 
-echo Starting flatnotes...
-cd ${APP_PATH}
-exec gosu ${PUID}:${PGID} \
-  python -m \
-  uvicorn \
-  main:app \
-  --app-dir flatnotes \
-  --host 0.0.0.0 \
-  --port 8080 \
-  --proxy-headers \
-  --forwarded-allow-ips "*"
+if [ `id -u` -eq 0 ] && [ `id -g` -eq 0 ]; then
+    set -e
+    
+    USERNAME=flatnotes
+    
+    echo Setting up user and group...
+    addgroup \
+      --gid ${PGID} \
+      ${USERNAME} \
+      || echo "Group '${PGID}' already exists."
+    
+    adduser \
+      --disabled-password \
+      --gecos "" \
+      --uid ${PUID} \
+      --gid ${PGID} \
+      ${USERNAME} \
+      || echo "User '${PUID}' already exists."
+    
+    echo Setting file permissions...
+    chown -R ${PUID}:${PGID} ${FLATNOTES_PATH}
+
+    echo Starting flatnotes...
+    cd ${APP_PATH}
+    exec gosu ${PUID}:${PGID} \
+      python -m \
+      uvicorn \
+      main:app \
+      --app-dir flatnotes \
+      --host 0.0.0.0 \
+      --port ${PORT} \
+      --proxy-headers \
+      --forwarded-allow-ips "*"
+else
+    echo "A user was set by docker, skipping permissions setup."
+    exec python -m \
+      uvicorn \
+      main:app \
+      --app-dir flatnotes \
+      --host 0.0.0.0 \
+      --port ${PORT} \
+      --proxy-headers \
+      --forwarded-allow-ips "*"
+fi


### PR DESCRIPTION
This commit fix issue https://github.com/dullage/flatnotes/issues/120 by adding a check that will determine if the sh script was started with a docker user specified or not. 

If the script is run with a docker user, it will simply execute the python exec. If no docker user is specified, it will perform the usual permissions configuration.
