### PR TITLE
Add more confirmations for unsaved notes.

### DIFF
--- a/flatnotes/src/components/NoteViewerEditor.vue
+++ b/flatnotes/src/components/NoteViewerEditor.vue
@@ -60,7 +60,7 @@
             v-if="editMode == true"
             type="button"
             class="bttn"
-            @click="cancelNote"
+            @click="confirmCancelNote"
           >
             <b-icon icon="arrow-return-left"></b-icon> Cancel
           </button>
@@ -302,7 +302,7 @@ export default {
 
     setBeforeUnloadConfirmation: function (enable = true) {
       if (enable) {
-        window.onbeforeunload = function() {
+        window.onbeforeunload = function () {
           return true;
         };
       } else {
@@ -517,24 +517,40 @@ export default {
     },
 
     cancelNote: function () {
-		this.$bvModal.msgBoxConfirm(`Are you sure you want to close the note '${this.currentNote.title}' without saving?`,
-			{
-				centered: true,
-				title: "Confirm Closure",
-				okTitle: "Yes, Close",
-				okVariant: "warning",	
-			})
-			.then(function (response) {
-			  if (response == true) {
-				localStorage.removeItem(this.currentNote.title);
-				if (this.currentNote.lastModified == null) {
-					// Cancelling a new note
-					EventBus.$emit("navigate", constants.basePaths.home);
-				} else {
-					this.setEditMode(false);
-				}
-			  }
-			});
+      localStorage.removeItem(this.currentNote.title);
+      if (this.currentNote.lastModified == null) {
+        // Cancelling a new note
+        EventBus.$emit("navigate", constants.basePaths.home);
+      } else {
+        this.setEditMode(false);
+      }
+    },
+
+    confirmCancelNote: function () {
+      let parent = this;
+      let newContent = this.getEditorContent();
+      if (
+        newContent != this.currentNote.content ||
+        this.titleInput != this.currentNote.title
+      ) {
+        this.$bvModal
+          .msgBoxConfirm(
+            `Are you sure you want to close the note '${this.currentNote.title}' without saving?`,
+            {
+              centered: true,
+              title: "Confirm Closure",
+              okTitle: "Yes, Close",
+              okVariant: "warning",
+            }
+          )
+          .then(function (response) {
+            if (response == true) {
+              parent.cancelNote();
+            }
+          });
+      } else {
+        this.cancelNote();
+      }
     },
 
     deleteNote: function () {

--- a/flatnotes/src/components/NoteViewerEditor.vue
+++ b/flatnotes/src/components/NoteViewerEditor.vue
@@ -517,13 +517,24 @@ export default {
     },
 
     cancelNote: function () {
-      localStorage.removeItem(this.currentNote.title);
-      if (this.currentNote.lastModified == null) {
-        // Cancelling a new note
-        EventBus.$emit("navigate", constants.basePaths.home);
-      } else {
-        this.setEditMode(false);
-      }
+		this.$bvModal.msgBoxConfirm(`Are you sure you want to close the note '${this.currentNote.title}' without saving?`,
+			{
+				centered: true,
+				title: "Confirm Closure",
+				okTitle: "Yes, Close",
+				okVariant: "warning",	
+			})
+			.then(function (response) {
+			  if (response == true) {
+				localStorage.removeItem(this.currentNote.title);
+				if (this.currentNote.lastModified == null) {
+					// Cancelling a new note
+					EventBus.$emit("navigate", constants.basePaths.home);
+				} else {
+					this.setEditMode(false);
+				}
+			  }
+			});
     },
 
     deleteNote: function () {

--- a/flatnotes/src/components/NoteViewerEditor.vue
+++ b/flatnotes/src/components/NoteViewerEditor.vue
@@ -300,11 +300,22 @@ export default {
       return this.currentNote.content;
     },
 
+    setBeforeUnloadConfirmation: function (enable = true) {
+      if (enable) {
+        window.onbeforeunload = function() {
+          return true;
+        };
+      } else {
+        window.onbeforeunload = null;
+      }
+    },
+
     setEditMode: function (editMode = true) {
       let parent = this;
 
       // To Edit Mode
       if (editMode === true) {
+        this.setBeforeUnloadConfirmation(true);
         this.titleInput = this.currentNote.title;
         let draftContent = localStorage.getItem(this.currentNote.title);
 
@@ -338,6 +349,7 @@ export default {
       else {
         this.titleInput = null;
         this.initialContent = null;
+        this.setBeforeUnloadConfirmation(false);
         this.editMode = false;
       }
     },


### PR DESCRIPTION
**Accidentally made modifications that closed the commit, the original commit can be found here https://github.com/dullage/flatnotes/pull/121**

Added a binding to onbeforeunload so that most major browsers warn users of data loss if they close the page while creating or editing a note. This binding should also display this message if the user attempts to close the entire browser (meaning that locally saved text would be lost), assuming the user has not disabled the warning in their settings.

The second change concerns the behavior of the cancel button. Instead of directly deleting the locally saved text and leaving edit mode, the application will ask for a confirmation as with the delete button. I've made this change so that a front-end user who accidentally presses the close button while creating or editing a note doesn't immediately lose all its contents.

Feel free to modify or delete features if you're not comfortable with any of them in their current state.
