### PR TITLE
Allow root URL path to be configured via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ docker run -d \
   -e "FLATNOTES_USERNAME=user" \
   -e "FLATNOTES_PASSWORD=changeMe!" \
   -e "FLATNOTES_SECRET_KEY=aLongRandomSeriesOfCharacters" \
+  -e "FLATNOTES_ROOT_PATH=/flatnotes" \
   -v "$(pwd)/data:/data" \
   -p "8080:8080" \
   dullage/flatnotes:latest
@@ -87,6 +88,7 @@ services:
       FLATNOTES_USERNAME: "user"
       FLATNOTES_PASSWORD: "changeMe!"
       FLATNOTES_SECRET_KEY: "aLongRandomSeriesOfCharacters"
+      FLATNOTES_ROOT_PATH: "/flatnotes"
     volumes:
       - "./data:/data"
       # Optional. Allows you to save the search index in a different location: 

--- a/flatnotes/config.py
+++ b/flatnotes/config.py
@@ -27,6 +27,8 @@ class Config:
 
         self.totp_key = self.get_totp_key()
 
+        self.root_path = self.get_root_path()
+
     @classmethod
     def get_env(cls, key, mandatory=False, default=None, cast_int=False):
         """Get an environment variable."""
@@ -100,6 +102,9 @@ class Config:
         if totp_key:
             totp_key = b32encode(totp_key.encode("utf-8"))
         return totp_key
+
+    def get_root_path(self):
+        return self.get_env("FLATNOTES_ROOT_PATH", mandatory=False, default="")
 
 
 config = Config()

--- a/flatnotes/src/api.js
+++ b/flatnotes/src/api.js
@@ -8,7 +8,7 @@ const api = axios.create();
 
 api.interceptors.request.use(
   function (config) {
-    if (config.url !== "/api/token") {
+    if (config.url !== `${window.flatnotesRootPath}/api/token`) {
       const token = getToken();
       config.headers.Authorization = `Bearer ${token}`;
     }

--- a/flatnotes/src/components/App.js
+++ b/flatnotes/src/components/App.js
@@ -61,7 +61,7 @@ export default {
     loadConfig: function () {
       let parent = this;
       api
-        .get("/api/config")
+        .get(`${window.flatnotesRootPath}/api/config`)
         .then(function (response) {
           parent.authType = response.data.authType;
         })
@@ -74,7 +74,8 @@ export default {
 
     route: function () {
       let path = window.location.pathname.split("/");
-      let basePath = `/${path[1]}`;
+      let rootPathParts = window.flatnotesRootPath.split("/").length;
+      let basePath = `${window.flatnotesRootPath}/${path[rootPathParts]}`;
 
       this.$bvModal.hide("search-modal");
 
@@ -102,7 +103,7 @@ export default {
 
       // Note
       else if (basePath == constants.basePaths.note) {
-        this.noteTitle = decodeURIComponent(path[2]);
+        this.noteTitle = decodeURIComponent(path[rootPathParts + 1]);
         this.updateDocumentTitle(this.noteTitle);
         this.currentView = this.views.note;
       }

--- a/flatnotes/src/components/Login.vue
+++ b/flatnotes/src/components/Login.vue
@@ -129,7 +129,7 @@ export default {
     login: function () {
       let parent = this;
       api
-        .post("/api/token", {
+        .post(`${window.flatnotesRootPath}/api/token`, {
           username: this.usernameInput,
           password:
             this.authType == constants.authTypes.totp

--- a/flatnotes/src/components/NoteViewerEditor.vue
+++ b/flatnotes/src/components/NoteViewerEditor.vue
@@ -278,7 +278,7 @@ export default {
       let parent = this;
       this.noteLoadFailed = false;
       api
-        .get(`/api/notes/${encodeURIComponent(title)}`)
+        .get(`${window.flatnotesRootPath}/api/notes/${encodeURIComponent(title)}`)
         .then(function (response) {
           parent.currentNote = new Note(
             response.data.title,
@@ -452,7 +452,7 @@ export default {
       // New Note
       if (this.currentNote.lastModified == null) {
         api
-          .post(`/api/notes`, {
+          .post(`${window.flatnotesRootPath}/api/notes`, {
             title: this.titleInput,
             content: newContent,
           })
@@ -477,7 +477,7 @@ export default {
         this.titleInput != this.currentNote.title
       ) {
         api
-          .patch(`/api/notes/${encodeURIComponent(this.currentNote.title)}`, {
+          .patch(`${window.flatnotesRootPath}/api/notes/${encodeURIComponent(this.currentNote.title)}`, {
             newTitle: this.titleInput,
             newContent: newContent,
           })
@@ -578,7 +578,7 @@ export default {
           if (response == true) {
             api
               .delete(
-                `/api/notes/${encodeURIComponent(parent.currentNote.title)}`
+                `${window.flatnotesRootPath}/api/notes/${encodeURIComponent(parent.currentNote.title)}`
               )
               .then(function () {
                 parent.$emit("note-deleted");
@@ -611,7 +611,8 @@ export default {
       // Upload the image then use the callback to insert the URL into the editor
       this.postAttachment(file).then(function (success) {
         if (success === true) {
-          callback(`/attachments/${encodeURIComponent(file.name)}`, altText);
+          // Use relative path so that the attachment URL stored in the note's markdown file works with any flatnotesRootPath.
+          callback(`../attachments/${encodeURIComponent(file.name)}`, altText);
         }
       });
     },
@@ -633,7 +634,7 @@ export default {
       const formData = new FormData();
       formData.append("file", file);
       return api
-        .post("/api/attachments", formData, {
+        .post(`${window.flatnotesRootPath}/api/attachments`, formData, {
           headers: {
             "Content-Type": "multipart/form-data",
           },

--- a/flatnotes/src/components/RecentlyModified.vue
+++ b/flatnotes/src/components/RecentlyModified.vue
@@ -68,7 +68,7 @@ export default {
       let parent = this;
       this.loadingFailed = false;
       api
-        .get("/api/search", {
+        .get(`${window.flatnotesRootPath}/api/search`, {
           params: {
             term: "*",
             sort: "lastModified",

--- a/flatnotes/src/components/SearchResults.vue
+++ b/flatnotes/src/components/SearchResults.vue
@@ -209,7 +209,7 @@ export default {
       this.searchFailed = false;
       this.searchResultsIncludeHighlights = false;
       api
-        .get("/api/search", { params: { term: this.searchTerm } })
+        .get(`${window.flatnotesRootPath}/api/search`, { params: { term: this.searchTerm } })
         .then(function (response) {
           parent.searchResults = [];
           if (response.data.length == 0) {

--- a/flatnotes/src/constants.js
+++ b/flatnotes/src/constants.js
@@ -1,10 +1,10 @@
 // Base Paths
 export const basePaths = {
-  home: "/",
-  login: "/login",
-  note: "/note",
-  search: "/search",
-  new: "/new",
+  home: `${window.flatnotesRootPath}/`,
+  login: `${window.flatnotesRootPath}/login`,
+  note: `${window.flatnotesRootPath}/note`,
+  search: `${window.flatnotesRootPath}/search`,
+  new: `${window.flatnotesRootPath}/new`,
 };
 
 // Params

--- a/flatnotes/src/index.html
+++ b/flatnotes/src/index.html
@@ -22,6 +22,7 @@
 
 <body class="h-100 pt-3">
   <div id="app"></div>
+  <script>window.flatnotesRootPath="FLATNOTES_ROOT_PATH";</script>
   <script src="index.js"></script>
 </body>
 

--- a/flatnotes/src/tokenStorage.js
+++ b/flatnotes/src/tokenStorage.js
@@ -1,7 +1,7 @@
 const tokenStorageKey = "token";
 
 function getCookieString(token) {
-  return `${tokenStorageKey}=${token}; path=/attachments; SameSite=Strict`;
+  return `${tokenStorageKey}=${token}; path=${window.flatnotesRootPath}/attachments; SameSite=Strict`;
 }
 
 export function setToken(token, persist = false) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "flatnotes/src/index.html",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "parcel build flatnotes/src/index.html --out-dir flatnotes/dist",
+    "build": "parcel build --public-url FLATNOTES_ROOT_PATH flatnotes/src/index.html --out-dir flatnotes/dist",
     "watch": "parcel flatnotes/src/index.html --out-dir flatnotes/dist"
   },
   "author": "Adam Dullage",


### PR DESCRIPTION
Hi there!

I'm attempting to carry on the torch from https://github.com/dullage/flatnotes/pull/71 to address https://github.com/dullage/flatnotes/issues/49

It took some finagling to get FastAPI to serve at the specified path, but I found a combination that works.

On the frontend side, the main idea I went with is to dynamically inject the root URL path at load-time into a global variable at `window.flatnotesRootPath = FLATNOTES_ROOT_PATH`. For the static assets, we set the public-url for Parcel at build time to `FLATNOTES_ROOT_PATH`.  At runtime we replace `FLATNOTES_ROOT_PATH` with the actual root path when serving `index.html`.

Summary of changes:
- Add `--public-url FLATNOTES_ROOT_PATH` in parcel build
- String replace `FLATNOTES_ROOT_PATH` with the real root path in main.py
- Use root path when routing and getting note title from URL in App.js
- Update all uses of `/api/...` in JS to use the root path: `${window.flatnotesRootPath}/api/...`
    - This feels not great... maybe ought to pass it into components the same way authType is? Open to suggestions.
- Make the `constants.basePaths` in JS use `${window.flatnotesRootPath}` as a prefix - once again not great.
    - Could go through and update all uses of `constants.basePaths.*` to include the prefix, but updating it directly in the constants file makes for fewer changes. Maybe add some utility methods to get the basePaths that include the prefix?
- Use `${window.flatnotesRootPath}` as prefix in uses of `/api/attachments` in JS.
- Make `/attachments/*` URLs used in note files relative so that they work no matter what the `flatnotesRootPath` is.