### PR TITLE
Reduce size of Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_DIR=/build
 
-# Build Container
+# Client Build Container
 FROM --platform=$BUILDPLATFORM python:3.11-slim-bullseye AS build
 
 ARG BUILD_DIR
@@ -16,6 +16,24 @@ RUN npm ci
 COPY client ./client
 RUN npm run build
 
+# Pipenv Build Container
+FROM python:3.11-alpine3.19 as pipenv-build
+
+ARG BUILD_DIR
+
+ENV APP_PATH=/app
+
+RUN apk add --no-cache build-base rust cargo libffi libffi-dev libssl3 openssl-dev
+
+RUN pip install --no-cache-dir pipenv
+
+WORKDIR ${APP_PATH}
+
+COPY LICENSE Pipfile Pipfile.lock ./
+RUN mkdir .venv
+RUN pipenv install --deploy --ignore-pipfile && \
+    pipenv --clear
+
 # Runtime Container
 FROM python:3.11-alpine3.19
 
@@ -30,18 +48,13 @@ ENV FLATNOTES_PATH=/data
 RUN mkdir -p ${APP_PATH}
 RUN mkdir -p ${FLATNOTES_PATH}
 
-RUN apk add --no-cache su-exec curl
-
-RUN pip install --no-cache-dir pipenv
+RUN apk add --no-cache su-exec libssl3 libgcc curl
 
 WORKDIR ${APP_PATH}
 
-COPY LICENSE Pipfile Pipfile.lock ./
-RUN pipenv install --deploy --ignore-pipfile --system && \
-    pipenv --clear
-
 COPY server ./server
 COPY --from=build ${BUILD_DIR}/client/dist ./client/dist
+COPY --from=pipenv-build ${APP_PATH}/.venv/lib/python3.11/site-packages/ /usr/local/lib/python3.11/site-packages/
 
 VOLUME /data
 EXPOSE 8080/tcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY client ./client
 RUN npm run build
 
 # Runtime Container
-FROM python:3.11-slim-bullseye
+FROM python:3.11-alpine3.19
 
 ARG BUILD_DIR
 
@@ -30,17 +30,15 @@ ENV FLATNOTES_PATH=/data
 RUN mkdir -p ${APP_PATH}
 RUN mkdir -p ${FLATNOTES_PATH}
 
-RUN apt update && apt install -y \
-    curl \
-    gosu \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache su-exec curl
 
-RUN pip install pipenv
+RUN pip install --no-cache-dir pipenv
 
 WORKDIR ${APP_PATH}
 
 COPY LICENSE Pipfile Pipfile.lock ./
-RUN pipenv install --deploy --ignore-pipfile --system
+RUN pipenv install --deploy --ignore-pipfile --system && \
+    pipenv --clear
 
 COPY server ./server
 COPY --from=build ${BUILD_DIR}/client/dist ./client/dist

--- a/Dockerfile.experimental
+++ b/Dockerfile.experimental
@@ -1,6 +1,6 @@
 ARG BUILD_DIR=/build
 
-# Build Container
+# Client Build Container
 FROM --platform=$BUILDPLATFORM python:3.11-slim-bullseye AS build
 
 ARG BUILD_DIR
@@ -16,14 +16,32 @@ RUN npm ci
 COPY client ./client
 RUN npm run build
 
+# Pipenv Build Container
+FROM python:3.11-alpine3.19 as pipenv-build
+
+ARG BUILD_DIR
+
+ENV APP_PATH=/app
+
+RUN apk add --no-cache build-base rust cargo libffi libffi-dev libssl3 openssl-dev
+
+RUN pip install --no-cache-dir pipenv
+
+WORKDIR ${APP_PATH}
+
+COPY LICENSE Pipfile Pipfile.lock ./
+RUN mkdir .venv
+RUN pipenv install --deploy --ignore-pipfile && \
+    pipenv --clear
+
 # Runtime Container
-FROM python:3.11-slim-bullseye
+FROM python:3.11-alpine3.19
 
 ARG BUILD_DIR
 
 ENV PUID=1000
 ENV PGID=1000
-ENV EXEC_TOOL=gosu
+ENV EXEC_TOOL=su-exec
 
 ENV APP_PATH=/app
 ENV FLATNOTES_PATH=/data
@@ -31,21 +49,13 @@ ENV FLATNOTES_PATH=/data
 RUN mkdir -p ${APP_PATH}
 RUN mkdir -p ${FLATNOTES_PATH}
 
-RUN apt update && apt install -y \
-    curl \
-    gosu \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN pip install --no-cache-dir pipenv
+RUN apk add --no-cache su-exec libssl3 libgcc curl
 
 WORKDIR ${APP_PATH}
 
-COPY LICENSE Pipfile Pipfile.lock ./
-RUN pipenv install --deploy --ignore-pipfile --system && \
-    pipenv --clear
-
 COPY server ./server
 COPY --from=build ${BUILD_DIR}/client/dist ./client/dist
+COPY --from=pipenv-build ${APP_PATH}/.venv/lib/python3.11/site-packages/ /usr/local/lib/python3.11/site-packages/
 
 VOLUME /data
 EXPOSE 8080/tcp

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ if [ `id -u` -eq 0 ] && [ `id -g` -eq 0 ]; then
     chown -R ${PUID}:${PGID} ${FLATNOTES_PATH}
 
     echo Starting flatnotes as user ${PUID}...
-    exec su-exec ${PUID}:${PGID} ${flatnotes_command}
+    exec ${EXEC_TOOL} ${PUID}:${PGID} ${flatnotes_command}
       
 else
     echo "A user was set by docker, skipping file permission changes."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -31,7 +31,7 @@ if [ `id -u` -eq 0 ] && [ `id -g` -eq 0 ]; then
     chown -R ${PUID}:${PGID} ${FLATNOTES_PATH}
 
     echo Starting flatnotes as user ${PUID}...
-    exec gosu ${PUID}:${PGID} ${flatnotes_command}
+    exec su-exec ${PUID}:${PGID} ${flatnotes_command}
       
 else
     echo "A user was set by docker, skipping file permission changes."


### PR DESCRIPTION
With some modifications to the Dockerfile I have achieved a 100MB size reduction in the resulting container image under my x86_64 test machine (264MB -> 165MB)

Changes done are:
 - Used the `python:3.11-alpine3.19` image as runtime container base
 - Replaced `gosu` with `su-exec` from Alpine Linux world
 - Cleaned pip and pipenv package cache from resulting runtime image

I've found it to work great under my setup so far, however have not tested the authentication methods thoroughly yet
