### PR TITLE
Entrypoint script fix for updated Flatnotes installs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+[ "$EXEC_TOOL" ] || EXEC_TOOL=gosu
+[ "$FLATNOTES_PORT" ] || FLATNOTES_PORT=8080
+
 set -e
 
 echo "\


### PR DESCRIPTION
Fix for #178

Users updating Flatnotes Docker containers from an old version are facing startup crashes due to the newly introduced `EXEC_TOOL` environment variable being undefined in their originally older containers

Added the following default value definitions to the `entrypoint.sh` script:
```
[ "$EXEC_TOOL" ] || EXEC_TOOL=gosu
[ "$FLATNOTES_PORT" ] || FLATNOTES_PORT=8080
```
(I believe the new `FLATNOTES_PORT` envvar to be affected as well so also added it a default value)

You can read such code as «Either $VAR is already defined or we set it a default value»