### PR TITLE
Prevent existing notes from being replaced when renaming a note

### DIFF
--- a/server/notes/file_system/file_system.py
+++ b/server/notes/file_system/file_system.py
@@ -80,6 +80,10 @@ class FileSystemNotes(BaseNotes):
         filepath = self._path_from_title(title)
         if data.new_title is not None:
             new_filepath = self._path_from_title(data.new_title)
+            if filepath != new_filepath and os.path.isfile(new_filepath):
+                raise FileExistsError(
+                    f"Failed to rename. '{data.new_title}' already exists."
+                )
             os.rename(filepath, new_filepath)
             title = data.new_title
             filepath = new_filepath


### PR DESCRIPTION
Fixes an issue where renaming a note to an already existing note title silently replace the existing note.

`os.rename(src, dst, *, src_dir_fd=None, dst_dir_fd=None)` [source](https://docs.python.org/3/library/os.html#os.rename)
- On Windows, if `dst` exists a `FileExistsError` is always raised.
- On Unix, if both are files, `dst` will be replaced silently if the user has permission.

Before:

https://github.com/dullage/flatnotes/assets/55848461/caec6cce-2292-43d1-aba7-adff05f526f4

After:

https://github.com/dullage/flatnotes/assets/55848461/0ea88dfe-1126-4a8d-88f8-7fd95ad81f41
