### PR TITLE
Dockerfile.experimental updates

### DIFF
--- a/Dockerfile.experimental
+++ b/Dockerfile.experimental
@@ -8,7 +8,14 @@ ARG BUILD_DIR
 RUN mkdir ${BUILD_DIR}
 WORKDIR ${BUILD_DIR}
 
-COPY package.json package-lock.json vite.config.js .htmlnanorc ./
+COPY .htmlnanorc \
+    package.json \
+    package-lock.json \
+    postcss.config.js \
+    tailwind.config.js \
+    vite.config.js \
+    ./
+
 RUN npm ci
 
 COPY client ./client

--- a/Dockerfile.experimental
+++ b/Dockerfile.experimental
@@ -40,6 +40,7 @@ ARG BUILD_DIR
 ENV PUID=1000
 ENV PGID=1000
 ENV EXEC_TOOL=su-exec
+ENV FLATNOTES_PORT=8080
 
 ENV APP_PATH=/app
 ENV FLATNOTES_PATH=/data
@@ -55,10 +56,11 @@ COPY server ./server
 COPY --from=build ${BUILD_DIR}/client/dist ./client/dist
 COPY --from=pipenv-build ${APP_PATH}/.venv/lib/python3.11/site-packages/ /usr/local/lib/python3.11/site-packages/
 
-VOLUME /data
-EXPOSE 8080/tcp
-HEALTHCHECK --interval=60s --timeout=10s CMD curl -f http://localhost:8080/health || exit 1
+COPY entrypoint.sh healthcheck.sh /
+RUN chmod +x /entrypoint.sh /healthcheck.sh
 
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
+VOLUME /data
+EXPOSE ${FLATNOTES_PORT}/tcp
+HEALTHCHECK --interval=60s --timeout=10s CMD /healthcheck.sh
+
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile.experimental
+++ b/Dockerfile.experimental
@@ -22,7 +22,7 @@ COPY client ./client
 RUN npm run build
 
 # Pipenv Build Container
-FROM python:3.11-alpine3.19 as pipenv-build
+FROM python:3.11-alpine3.20 as pipenv-build
 
 ARG BUILD_DIR
 
@@ -40,7 +40,7 @@ RUN pipenv install --deploy --ignore-pipfile && \
     pipenv --clear
 
 # Runtime Container
-FROM python:3.11-alpine3.19
+FROM python:3.11-alpine3.20
 
 ARG BUILD_DIR
 


### PR DESCRIPTION
This keeps the Dockerfile.experimental up to date for feature parity with the main Dockerfile:

- cb64daddcb14beadc4ad55daf87f789170b33f46 adds support for the FLATNOTES_PORT envvar and is equivalent to 52bca5919d0ad0d8f175c4ba9abc22f0be9a6793
- 116c593fa72bcbe1f9c3bddbfdd428165e49513c updates the dockerfile to account for tailwindcss, equivalent to 39857dcf7b1eb779e57a467e64fddbd7ae40bc84
- Additionally d0b93da1781e077be6523b690c636a357a49422c updates the base container's Alpine Linux version from 3.19 to 3.20

PS: I see support for alternate base URLs is ready! :tada: can't wait to try it out and finally integrate Flatnotes to my home server :D