### PR TITLE
Fix for running Flatnotes behind an authenticating reverse proxy

### DIFF
--- a/client/api.js
+++ b/client/api.js
@@ -14,7 +14,9 @@ api.interceptors.request.use(
   function (config) {
     if (config.url !== "api/token") {
       const token = getStoredToken();
-      config.headers.Authorization = `Bearer ${token}`;
+      if (token) {
+        config.headers.Authorization = `Bearer ${token}`;
+      }
     }
     return config;
   },


### PR DESCRIPTION
With the last base path support changes I'm almost there integrating Flatnotes to my home server! However I've found one last showstopper:

My home server runs a Lighttpd instance serving files over WebDAV plus a reverse proxy to plenty of other selfhosted apps (often Dockerized) running their own minimal webservers just like Flatnotes does
This haves the benefit of centralizing authentication in a single place (web browser deals with Lighttpd, handles the `Authorization` HTTP header and the proxied apps can forget about auth) and less security maintenance burden (instead of lots of different webservers from each app exposed to the internet, everything is gated behind Lighttpd which also gets auto-updated by Ubuntu's APT)

However currently this code at Flatnotes client-side JS overwrites the HTTP `Authorization` header unconditionally even if no token has even been stored, overwriting the browser+lighttpd-negotiated `Authorization` header and effectively deauthenticating from the server:

https://github.com/dullage/flatnotes/blob/ac1181532f7f541b7944746134364b5469a34a66/client/api.js#L14-L18

In the case where there's no stored token `getStoredToken()` returns `null`, and the `Authorization` header gets overwritten with the value `Bearer: null`

I have modified the code to never overwrite the header if there's no stored (`null`) token. This way:

 - Should the connection be already authenticated such that Flatnotes finds no 401 errors reaching its endpoints, it won't mess anymore with the underlying mechanism this was achieved through (Lighttpd reverse proxy in this case)
 - If connected directly to an authenticating Flatnotes server having the `Authorization` header set to `Bearer: null` and having no header at all should functionally be similar, so this * should * not introduce behavioral changes to those configurations (I have confirmed this testing with password auth)
