### PR TITLE
Add ability to pin notes

### DIFF
--- a/client/App.vue
+++ b/client/App.vue
@@ -44,6 +44,7 @@ getConfig()
   .then((data) => {
     globalStore.authType = data.authType;
     globalStore.hideRecentlyModified = data.hideRecentlyModified;
+    globalStore.hidePinnedNotes = data.hidePinnedNotes;
   })
   .catch((error) => {
     apiErrorHandler(error, toast);

--- a/client/globalStore.js
+++ b/client/globalStore.js
@@ -6,6 +6,7 @@ import { ref } from "vue";
 export const useGlobalStore = defineStore("global", () => {
   const authType = ref(constants.authTypes.password);
   const hideRecentlyModified = ref(true);
+  const hidePinnedNotes = ref(true);
 
-  return { authType, hideRecentlyModified };
+  return { authType, hideRecentlyModified, hidePinnedNotes };
 });

--- a/client/partials/NavBar.vue
+++ b/client/partials/NavBar.vue
@@ -27,6 +27,7 @@ import {
   mdilMenu,
   mdilMonitor,
   mdilNoteMultiple,
+  mdilPin,
   mdilPlusCircle,
 } from "@mdi/light-js";
 import { computed, ref } from "vue";
@@ -65,6 +66,18 @@ const menuItems = [
         name: "search",
         query: {
           [params.searchTerm]: "*",
+          [params.sortBy]: searchSortOptions.title,
+        },
+      }),
+  },
+  {
+    label: "Pinned Notes",
+    icon: mdilPin,
+    command: () =>
+      router.push({
+        name: "search",
+        query: {
+          [params.searchTerm]: "tags:pinned",
           [params.sortBy]: searchSortOptions.title,
         },
       }),

--- a/client/views/Home.vue
+++ b/client/views/Home.vue
@@ -4,6 +4,7 @@
       <Logo class="mb-5" />
       <SearchInput class="mb-5 shadow-[0_0_20px] shadow-theme-shadow" />
       <LoadingIndicator
+        :class="{ hidden: globalStore.hideRecentlyModified}"
         ref="loadingIndicator"
         class="flex min-h-56 flex-col items-center"
         hideLoader
@@ -22,6 +23,26 @@
           <CustomButton :label="note.title" />
         </RouterLink>
       </LoadingIndicator>
+      <LoadingIndicator
+        :class="{ hidden: globalStore.hidePinnedNotes}"
+        ref="pinnedLoadingIndicator"
+        class="flex min-h-56 flex-col items-center"
+        hideLoader
+      >
+        <p
+          v-if="pinned.length > 0"
+          class="mb-2 text-xs font-bold text-theme-text-very-muted"
+        >
+          PINNED
+        </p>
+        <RouterLink
+          v-for="note in pinned"
+          :to="{ name: 'note', params: { title: note.title } }"
+          class="mb-1"
+        >
+          <CustomButton :label="note.title" />
+        </RouterLink>
+      </LoadingIndicator>
     </div>
   </div>
 </template>
@@ -31,7 +52,7 @@ import { useToast } from "primevue/usetoast";
 import { onMounted, ref, watch } from "vue";
 import { RouterLink } from "vue-router";
 
-import { mdiPencil } from "@mdi/js";
+import { mdiPencil, mdiPin } from "@mdi/js";
 import { apiErrorHandler, getNotes } from "../api.js";
 import CustomButton from "../components/CustomButton.vue";
 import LoadingIndicator from "../components/LoadingIndicator.vue";
@@ -41,28 +62,47 @@ import SearchInput from "../partials/SearchInput.vue";
 
 const globalStore = useGlobalStore();
 const loadingIndicator = ref();
+const pinnedLoadingIndicator = ref();
 const noNotesMessage =
   "Click the 'New Note' button at the top of the page to get started.";
+const noPinnedNotesMessage =
+  "You can pin a note by adding #pinned anywhere in the content of a note.";
 const notes = ref([]);
+const pinned = ref([]);
 const toast = useToast();
 
 function init() {
-  if (globalStore.hideRecentlyModified) {
-    return;
+  if (globalStore.hideRecentlyModified === false) {
+    getNotes("*", "lastModified", "desc", 5)
+      .then((data) => {
+        notes.value = data;
+        if (notes.value.length > 0) {
+          loadingIndicator.value.setLoaded();
+        } else {
+          loadingIndicator.value.setFailed(noNotesMessage, mdiPencil);
+        }
+      })
+      .catch((error) => {
+        loadingIndicator.value.setFailed();
+        apiErrorHandler(error, toast);
+      });
   }
-  getNotes("*", "lastModified", "desc", 5)
-    .then((data) => {
-      notes.value = data;
-      if (notes.value.length > 0) {
-        loadingIndicator.value.setLoaded();
-      } else {
-        loadingIndicator.value.setFailed(noNotesMessage, mdiPencil);
-      }
-    })
-    .catch((error) => {
-      loadingIndicator.value.setFailed();
-      apiErrorHandler(error, toast);
-    });
+
+  if (globalStore.hidePinnedNotes === false) {
+    getNotes("tags:pinned", "lastModified", "desc", 5)
+      .then((data) => {
+        pinned.value = data;
+        if (pinned.value.length > 0) {
+          pinnedLoadingIndicator.value.setLoaded();
+        } else {
+          pinnedLoadingIndicator.value.setFailed(noPinnedNotesMessage, mdiPin);
+        }
+      })
+      .catch((error) => {
+        pinnedLoadingIndicator.value.setFailed();
+        apiErrorHandler(error, toast);
+      });
+  }
 }
 
 // Watch to allow for delayed config load.

--- a/server/global_config.py
+++ b/server/global_config.py
@@ -10,6 +10,7 @@ class GlobalConfig:
         logger.debug("Loading global config...")
         self.auth_type: AuthType = self._load_auth_type()
         self.hide_recently_modified: bool = self._load_hide_recently_modified()
+        self.hide_pinned_notes: bool = self._load_hide_pinned_notes()
         self.path_prefix: str = self._load_path_prefix()
 
     def load_auth(self):
@@ -50,6 +51,10 @@ class GlobalConfig:
     def _load_hide_recently_modified(self):
         key = "FLATNOTES_HIDE_RECENTLY_MODIFIED"
         return get_env(key, mandatory=False, default=False, cast_bool=True)
+    
+    def _load_hide_pinned_notes(self):
+        key = "FLATNOTES_HIDE_PINNED_NOTES"
+        return get_env(key, mandatory=False, default=True, cast_bool=True)
 
     def _load_path_prefix(self):
         key = "FLATNOTES_PATH_PREFIX"
@@ -73,3 +78,4 @@ class AuthType(str, Enum):
 class GlobalConfigResponseModel(CustomBaseModel):
     auth_type: AuthType
     hide_recently_modified: bool
+    hide_pinned_notes: bool

--- a/server/main.py
+++ b/server/main.py
@@ -179,6 +179,7 @@ def get_config():
     return GlobalConfigResponseModel(
         auth_type=global_config.auth_type,
         hide_recently_modified=global_config.hide_recently_modified,
+        hide_pinned_notes=global_config.hide_pinned_notes,
     )
 
 


### PR DESCRIPTION
This pull request adds the ability to pin notes within the application. Notes can now be pinned by adding #pinned anywhere in the note content.

- Added functionality to mark notes as pinned using #pinned.
- Optionally display pinned notes on the home page by setting `FLATNOTES_HIDE_PINNED_NOTES` to false. Pinned notes are hidden by default on the home page.
-  View all your pinned notes via the menu button: Menu -> Pinned Notes


![recent-pinned-home-page](https://github.com/dullage/flatnotes/assets/55848461/0654fa78-6952-489d-888a-d4b939ffbf78)

![image](https://github.com/dullage/flatnotes/assets/55848461/334974cb-26af-40be-9de7-abe781a27975)



Default home page / `FLATNOTES_HIDE_PINNED_NOTES: "true"` 
![image](https://github.com/dullage/flatnotes/assets/55848461/168b121a-998c-4893-934d-9126c7b1d5af)