### PR TITLE
462dbb9 equivalent for Dockerfile.experimental

### DIFF
--- a/Dockerfile.experimental
+++ b/Dockerfile.experimental
@@ -60,7 +60,7 @@ RUN apk add --no-cache su-exec libssl3 libgcc curl
 WORKDIR ${APP_PATH}
 
 COPY server ./server
-COPY --from=build ${BUILD_DIR}/client/dist ./client/dist
+COPY --from=build --chmod=777 ${BUILD_DIR}/client/dist ./client/dist
 COPY --from=pipenv-build ${APP_PATH}/.venv/lib/python3.11/site-packages/ /usr/local/lib/python3.11/site-packages/
 
 COPY entrypoint.sh healthcheck.sh /


### PR DESCRIPTION
This updates the Dockerfile.experimental with the equivalent change from 462dbb9 for file permissions to work correctly

P.S.: Got my builds of 32-bit Flatnotes up at Docker Hub https://hub.docker.com/r/codeotto/flatnotes-arm32 I'll try to keep them up to date with tagged Flatnotes releases where not broken