### PR TITLE
Fixed permission issue when mounting new data directory.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ ENV APP_PATH=/app
 ENV FLATNOTES_PATH=/data
 
 RUN mkdir -p ${APP_PATH}
-RUN mkdir -p ${FLATNOTES_PATH}
+RUN mkdir -p ${FLATNOTES_PATH} && chown ${PUID}:${PGID} ${FLATNOTES_PATH}
 
 RUN apt update && apt install -y \
     curl \


### PR DESCRIPTION
The commit of v5.2.1
commit 462dbb9b6b1288d8d6cb8af361ab9fb48e812cb6
Author: Adam Dullage <adam@dullage.com>
Date:   Sun Jul 7 14:29:47 2024 +0100

    #213 - Set client file permissions in Dockerfile rather than entrypoint

made it so that containers started with empty directories fail with permission issue:

```
$ docker run -e "PUID=1000"   -e "PGID=1000"   -e "FLATNOTES_AUTH_TYPE=password"   -e "FLATNOTES_USERNAME=user"   -e "FLATNOTES_PASSWORD=changeMe!"   -e "FLATNOTES_SECRET_KEY=aLongRandomSeriesOfCharacters"   -v "datavol:/data"   -p "8080:8080"   dullage/flatnotes:v5.2.0
======================================
======== Welcome to flatnotes ========
======================================

If you enjoy using flatnotes, please
consider sponsoring the project at:

https://sponsor.flatnotes.io

It would really make my day 🙏.

──────────────────────────────────────

Setting file permissions...
Starting flatnotes as user 1000...
2024-07-23 13:50:51 [INFO]: Loading existing index
2024-07-23 13:50:51 [INFO]: Index synchronized
2024-07-23 13:50:51 [INFO]: Replacing href value for base element in 'client/dist/index.html' with '/'.
INFO:     Started server process [1]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
```

```
$ docker run -e "PUID=1000"   -e "PGID=1000"   -e "FLATNOTES_AUTH_TYPE=password"   -e "FLATNOTES_USERNAME=user"   -e "FLATNOTES_PASSWORD=changeMe!"   -e "FLATNOTES_SECRET_KEY=aLongRandomSeriesOfCharacters"   -v "anotherdatavol:/data"   -p "8080:8080"   dullage/flatnotes:v5.2.1
======================================
======== Welcome to flatnotes ========
======================================

If you enjoy using flatnotes, please
consider sponsoring the project at:

https://sponsor.flatnotes.io

It would really make my day 🙏.

──────────────────────────────────────

Setting file permissions...
Starting flatnotes as user 1000...
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/local/lib/python3.11/site-packages/uvicorn/__main__.py", line 4, in <module>
    uvicorn.main()
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/uvicorn/main.py", line 409, in main
    run(
  File "/usr/local/lib/python3.11/site-packages/uvicorn/main.py", line 575, in run
    server.run()
  File "/usr/local/lib/python3.11/site-packages/uvicorn/server.py", line 65, in run
    return asyncio.run(self.serve(sockets=sockets))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "uvloop/loop.pyx", line 1517, in uvloop.loop.Loop.run_until_complete
  File "/usr/local/lib/python3.11/site-packages/uvicorn/server.py", line 69, in serve
    await self._serve(sockets)
  File "/usr/local/lib/python3.11/site-packages/uvicorn/server.py", line 76, in _serve
    config.load()
  File "/usr/local/lib/python3.11/site-packages/uvicorn/config.py", line 433, in load
    self.loaded_app = import_from_string(self.app)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/uvicorn/importer.py", line 19, in import_from_string
    module = importlib.import_module(module_str)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/app/server/main.py", line 19, in <module>
    note_storage: BaseNotes = global_config.load_note_storage()
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/server/global_config.py", line 26, in load_note_storage
    return FileSystemNotes()
           ^^^^^^^^^^^^^^^^^
  File "/app/server/notes/file_system/file_system.py", line 54, in __init__
    self.index = self._load_index()
                 ^^^^^^^^^^^^^^^^^^
  File "/app/server/notes/file_system/file_system.py", line 186, in _load_index
    os.mkdir(self._index_path)
PermissionError: [Errno 13] Permission denied: '/data/.flatnotes'
```