### PR TITLE
feat: Supports hyphens in tags

### DIFF
--- a/server/notes/file_system/file_system.py
+++ b/server/notes/file_system/file_system.py
@@ -52,8 +52,7 @@ class FileSystemNotes(BaseNotes):
                 f"'{self.storage_path}' is not a valid directory."
             )
         self.index = self._load_index()
-        clean = get_env("FLATNOTES_CLEAN_INDEX", default=False, cast_bool=True)
-        self._sync_index_with_retry(optimize=True, clean=clean)
+        self._sync_index_with_retry(optimize=True)
 
     def create(self, data: NoteCreate) -> Note:
         """Create a new note."""

--- a/server/notes/file_system/file_system.py
+++ b/server/notes/file_system/file_system.py
@@ -25,7 +25,7 @@ from ..base import BaseNotes
 from ..models import Note, NoteCreate, NoteUpdate, SearchResult
 
 MARKDOWN_EXT = ".md"
-INDEX_SCHEMA_VERSION = "4"
+INDEX_SCHEMA_VERSION = "5"
 
 StemmingFoldingAnalyzer = StemmingAnalyzer() | CharsetFilter(accent_map)
 

--- a/server/notes/file_system/file_system.py
+++ b/server/notes/file_system/file_system.py
@@ -43,7 +43,9 @@ class IndexSchema(SchemaClass):
 class FileSystemNotes(BaseNotes):
     TAGS_RE = re.compile(r"(?:(?<=^#)|(?<=\s#))[a-zA-Z0-9_-]+(?=\s|$)")
     CODEBLOCK_RE = re.compile(r"`{1,3}.*?`{1,3}", re.DOTALL)
-    TAGS_WITH_HASH_RE = re.compile(r"(?:(?<=^)|(?<=\s))#[a-zA-Z0-9_-]+(?=\s|$)")
+    TAGS_WITH_HASH_RE = re.compile(
+        r"(?:(?<=^)|(?<=\s))#[a-zA-Z0-9_-]+(?=\s|$)"
+    )
 
     def __init__(self):
         self.storage_path = get_env("FLATNOTES_PATH", mandatory=True)
@@ -196,11 +198,8 @@ class FileSystemNotes(BaseNotes):
         - The content without the tags.
         - A set of tags converted to lowercase."""
         content_ex_codeblock = re.sub(cls.CODEBLOCK_RE, "", content)
-        logger.debug(f"Content without codeblocks: {content_ex_codeblock}")
         _, tags = cls._re_extract(cls.TAGS_RE, content_ex_codeblock)
-        logger.debug(f"Tags extracted: {tags}")
         content_ex_tags, _ = cls._re_extract(cls.TAGS_RE, content)
-        logger.debug(f"Content without tags: {content_ex_tags}")
         try:
             tags = [tag.lower() for tag in tags]
             return (content_ex_tags, set(tags))
@@ -238,7 +237,6 @@ class FileSystemNotes(BaseNotes):
         indexed = set()
         writer = self.index.writer()
         if clean:
-            logger.info(f"Cleaning index {clean}")
             writer.mergetype = writing.CLEAR  # Clear the index
         with self.index.searcher() as searcher:
             for idx_note in searcher.all_stored_fields():
@@ -268,7 +266,6 @@ class FileSystemNotes(BaseNotes):
                     writer, self._get_by_filename(filename)
                 )
                 logger.info(f"'{filename}' added to index")
-
         writer.commit(optimize=optimize)
         logger.info("Index synchronized")
 


### PR DESCRIPTION
## Changes
- Change Regex to support the following characters: `a-Z`, `A-Z`, `0-9`,  or `_-`.
- Debug logs, I can remove them if need it

Related: https://github.com/dullage/flatnotes/issues/77

## Notes

Reading the code I understand that extracting the tags requires an index rebuild, that can be set as an environment variable `FLATNOTES_CLEAN_INDEX` during startup and execute once during the instance creation

<img width="602" alt="image" src="https://github.com/user-attachments/assets/900c3b1a-558d-483b-8481-9a2851aa9611">
