### PR TITLE
Authenticate the client before showing the home view

### DIFF
--- a/client/views/Home.vue
+++ b/client/views/Home.vue
@@ -44,11 +44,11 @@ import { useToast } from "primevue/usetoast";
 import { onMounted, ref, watch } from "vue";
 import { RouterLink } from "vue-router";
 
-import { apiErrorHandler, getNotes } from "../api.js";
+import { apiErrorHandler, getNotes, getTags } from "../api.js";
 import CustomButton from "../components/CustomButton.vue";
 import LoadingIndicator from "../components/LoadingIndicator.vue";
 import Logo from "../components/Logo.vue";
-import { searchSortOptions } from "../constants.js";
+import { searchSortOptions, authTypes } from "../constants.js";
 import { useGlobalStore } from "../globalStore.js";
 import SearchInput from "../partials/SearchInput.vue";
 
@@ -58,6 +58,13 @@ const notes = ref([]);
 const toast = useToast();
 
 function init() {
+  // Should the user authenticate before accessing the home view?
+  // Try an authenticated request and prompt for a login if needed.
+  if (![authTypes.none, authTypes.readOnly].includes(globalStore.config.authType)) {
+    getTags().catch((error) => {
+      apiErrorHandler(error, toast);
+    });
+  }
   if (globalStore.config.quickAccessHide) {
     return;
   }


### PR DESCRIPTION
When `FLATNOTES_QUICK_ACCESS_HIDE: true` the home view is indistinguishable between an authenticated and unauthenticated client. Specifically:
- Before the client logs in, "Menu" includes a "Log Out" button. This is confusing. When pressed, the client is actually prompted to log in.
- The "New Note" button is also visible. Before anything is saved server-side the client is asked to authenticate but given the behavior introduced by https://github.com/dullage/flatnotes/commit/b8f728c6d8b27c23b96970b1d50cf8e108ea4a34 it's probably necessary to authenticate the client before a local draft is created.

This change introduces an authenticated request during the home view initialization.
- If the request succeeds, there's no change to the current application flow.
- If the request fails, the client is redirected to log in. This is behavior introduced by this change.
The new logic is similar to the one used by the quick access feature but that logic isn't executed when quick access is disabled.

P.S.: I chose the getTags API call because it seems like a low-cost request to make.