### PR TITLE
Allow TOTP to be reused (within its lifetime)

### DIFF
--- a/server/auth/local/local.py
+++ b/server/auth/local/local.py
@@ -37,7 +37,6 @@ class LocalAuth(BaseAuth):
             self.totp_key = get_env("FLATNOTES_TOTP_KEY", mandatory=True)
             self.totp_key = b32encode(self.totp_key.encode("utf-8"))
             self.totp = TOTP(self.totp_key)
-            self.last_used_totp = None
             self._display_totp_enrolment()
 
     def login(self, data: Login) -> Token:
@@ -49,8 +48,7 @@ class LocalAuth(BaseAuth):
         # Check Password & TOTP
         expected_password = self.password
         if self.is_totp_enabled:
-            current_totp = self.totp.now()
-            expected_password += current_totp
+            expected_password += self.totp.now()
         password_correct = secrets.compare_digest(
             expected_password, data.password
         )
@@ -59,15 +57,8 @@ class LocalAuth(BaseAuth):
         if not (
             username_correct
             and password_correct
-            # Prevent TOTP from being reused
-            and (
-                self.is_totp_enabled is False
-                or current_totp != self.last_used_totp
-            )
         ):
             raise ValueError("Incorrect login credentials.")
-        if self.is_totp_enabled:
-            self.last_used_totp = current_totp
 
         # Create Token
         access_token = self._create_access_token(data={"sub": self.username})


### PR DESCRIPTION
When `FLATNOTES_AUTH_TYPE` is `totp` the user cannot log in, log out, and log back in within 30 seconds.
This change address the issue.

How to reproduce the issue:
1. Confirm that `FLATNOTES_AUTH_TYPE` is `totp`, `FLATNOTES_USERNAME` and `FLATNOTES_PASSWORD` are defined.
2. Log into Flatnotes and note the current 2FA code. (In your 2FA application)
3. Immediately log out and try to log back in.
4. Observe that the 2FA code hasn't changed. If it has, go to step (2).
5. Observe that login fails with an error message indicating incorrect credentials.

Expected results:
At step 5 login is successful given the correct username, password, and the current 2FA code.

Actual results:
Log in fails.

Discussion:
Flatnotes keeps track of the current 2FA code and [does not allow it to be reused](https://github.com/dullage/flatnotes/blob/a38ac15e0019f7459531afd29db6c1cb999327c8/server/auth/local/local.py#L65).
However the user can't get a new code on demand and [pyotp](https://pyauth.github.io/pyotp/_modules/pyotp/totp.html#TOTP) rotates codes every 30 seconds.
So if the user logs in, logs out, and tries to log in again before a new 2FA code is available they'll get a confusing "incorrect login credentials" message and no recourse.
Given the pyotp behavior I'm not sure what's the purpose of the current Flatnotes logic.

This change allows 2FA codes to be reused as long as they match `totp.now()`